### PR TITLE
`string::char`メソッドを実装

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -395,6 +395,11 @@ fn gen_il_method<'a>(
             Ok(RRType::new(Type::String))
         }
         // 仮実装
+        Type::String if ident == "chars" => {
+            p.push_il_text(format!("\tnewobj instance void class [mscorlib]System.Collections.Generic.List`1<char>::.ctor(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)"));
+            Ok(RRType::new(Type::Vec(RRType::new(Type::Char))))
+        }
+        // 仮実装
         Type::Vec(ref ty) if ident == "push" => {
             let arg = args.into_iter().next().unwrap();
             let token = arg.token;

--- a/src/typing.rs
+++ b/src/typing.rs
@@ -376,6 +376,13 @@ fn typing_method<'a>(
             Ok(RRType::new(Type::String))
         }
         // 仮実装
+        Type::String if ident == "chars" => {
+            if !args.is_empty() {
+                e0029(Rc::clone(&p.errors), (p.path, &p.lines, current_token), 0, args.len());
+            }
+            Ok(RRType::new(Type::Vec(RRType::new(Type::Char))))
+        }
+        // 仮実装
         Type::Vec(ty) if ident == "push" => {
             let arg_ty = typing(args.into_iter().next().unwrap(), st, p, false)?;
             type_inference(&mut RRType::clone(ty), &arg_ty);

--- a/tests/vec.ad
+++ b/tests/vec.ad
@@ -6,5 +6,10 @@ fn main() {
     assert_eq!(1, a[0]);
     assert_eq!(2, a[1]);
 
+    let abc = "abc".chars();
+    assert_eq!('a', abc[0]);
+    assert_eq!('b', abc[1]);
+    assert_eq!('c', abc[2]);
+
     println!("ok");
 }


### PR DESCRIPTION
Close #199 

```rust
﻿fn main() {
    let abc = "abc".chars();
    assert_eq!('a', abc[0]);
    assert_eq!('b', abc[1]);
    assert_eq!('c', abc[2]);
}
```