### PR TITLE
`Vec`型の型推論を修正

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -580,7 +580,7 @@ pub fn new_vec_node<'a>(
 ) -> Node<'a> {
     Node {
         kind: NodeKind::Vec {
-            ty: RRType::new(Type::Unknown),
+            ty: RRType::new(Type::Vec(RRType::new(Type::Unknown))),
             method: Box::new(method),
         },
         token,

--- a/src/typing.rs
+++ b/src/typing.rs
@@ -25,6 +25,7 @@ pub fn type_inference(source: &mut RRType, target: &RRType) {
             *source.borrow().borrow_mut() = ty;
         }
         (Type::Box(l), Type::Box(r)) |
+        (Type::Vec(l), Type::Vec(r)) |
         (Type::Ptr(l), Type::Ptr(r)) => type_inference(l, r),
         _ => (),  // Do nothing
     }
@@ -197,7 +198,7 @@ fn typing_vec<'a>(_current_token: &[Token], _st: &mut SymbolTable, p: &'a Progra
                 Ok(RRType::clone(&ty))
             }
             _ => {
-                e0014(Rc::clone(&p.errors), (p.path, &p.lines, method.token), &name, "Box");
+                e0014(Rc::clone(&p.errors), (p.path, &p.lines, method.token), &name, "Vec");
                 Err(())
             }
         }

--- a/tests/vec.ad
+++ b/tests/vec.ad
@@ -2,9 +2,14 @@ fn main() {
     let mut a: Vec<i32> = Vec::new();
     a.push(1);
     a.push(2);
-    a[0];
     assert_eq!(1, a[0]);
     assert_eq!(2, a[1]);
+
+    let mut a = Vec::new();
+    a.push('a');
+    a.push('b');
+    assert_eq!('a', a[0]);
+    assert_eq!('b', a[1]);
 
     let abc = "abc".chars();
     assert_eq!('a', abc[0]);


### PR DESCRIPTION
Fixes #201 

ついでにエラーメッセージのtypoも修正した